### PR TITLE
Support gaussdb dialect

### DIFF
--- a/tests/delete_test.go
+++ b/tests/delete_test.go
@@ -206,9 +206,9 @@ func TestDeleteSliceWithAssociations(t *testing.T) {
 	}
 }
 
-// only sqlite, postgres, sqlserver support returning
+// only sqlite, postgres, gaussdb, sqlserver support returning
 func TestSoftDeleteReturning(t *testing.T) {
-	if DB.Dialector.Name() != "sqlite" && DB.Dialector.Name() != "postgres" && DB.Dialector.Name() != "sqlserver" {
+	if DB.Dialector.Name() != "sqlite" && DB.Dialector.Name() != "postgres" && DB.Dialector.Name() != "gaussdb" && DB.Dialector.Name() != "sqlserver" {
 		return
 	}
 
@@ -233,7 +233,7 @@ func TestSoftDeleteReturning(t *testing.T) {
 }
 
 func TestDeleteReturning(t *testing.T) {
-	if DB.Dialector.Name() != "sqlite" && DB.Dialector.Name() != "postgres" && DB.Dialector.Name() != "sqlserver" {
+	if DB.Dialector.Name() != "sqlite" && DB.Dialector.Name() != "postgres" && DB.Dialector.Name() != "gaussdb" && DB.Dialector.Name() != "sqlserver" {
 		return
 	}
 

--- a/tests/error_translator_test.go
+++ b/tests/error_translator_test.go
@@ -39,7 +39,7 @@ func TestSupportedDialectorWithErrDuplicatedKey(t *testing.T) {
 		t.Fatalf("failed to connect database, got error %v", err)
 	}
 
-	dialectors := map[string]bool{"sqlite": true, "postgres": true, "mysql": true, "sqlserver": true}
+	dialectors := map[string]bool{"sqlite": true, "postgres": true, "gaussdb": true, "mysql": true, "sqlserver": true}
 	if supported, found := dialectors[db.Dialector.Name()]; !(found && supported) {
 		return
 	}
@@ -81,7 +81,7 @@ func TestSupportedDialectorWithErrForeignKeyViolated(t *testing.T) {
 		t.Fatalf("failed to connect database, got error %v", err)
 	}
 
-	dialectors := map[string]bool{"sqlite": true, "postgres": true, "mysql": true, "sqlserver": true}
+	dialectors := map[string]bool{"sqlite": true, "postgres": true, "gaussdb": true, "mysql": true, "sqlserver": true}
 	if supported, found := dialectors[db.Dialector.Name()]; !(found && supported) {
 		return
 	}

--- a/tests/multi_primary_keys_test.go
+++ b/tests/multi_primary_keys_test.go
@@ -41,7 +41,7 @@ func TestManyToManyWithMultiPrimaryKeys(t *testing.T) {
 		t.Skip("skip sqlite, sqlserver due to it doesn't support multiple primary keys with auto increment")
 	}
 
-	if name := DB.Dialector.Name(); name == "postgres" || name == "mysql" {
+	if name := DB.Dialector.Name(); name == "postgres" || name == "mysql" || name == "gaussdb" {
 		stmt := gorm.Statement{DB: DB}
 		stmt.Parse(&Blog{})
 		stmt.Schema.LookUpField("ID").Unique = true
@@ -141,6 +141,9 @@ func TestManyToManyWithCustomizedForeignKeys(t *testing.T) {
 
 	if name := DB.Dialector.Name(); name == "postgres" {
 		t.Skip("skip postgres due to it only allow unique constraint matching given keys")
+	}
+	if name := DB.Dialector.Name(); name == "gaussdb" {
+		t.Skip("skip gaussdb due to it only allow unique constraint matching given keys")
 	}
 
 	DB.Migrator().DropTable(&Blog{}, &Tag{}, "blog_tags", "locale_blog_tags", "shared_blog_tags")
@@ -266,6 +269,10 @@ func TestManyToManyWithCustomizedForeignKeys2(t *testing.T) {
 
 	if name := DB.Dialector.Name(); name == "postgres" || name == "mysql" {
 		t.Skip("skip postgres due to it only allow unique constraint matching given keys")
+	}
+
+	if name := DB.Dialector.Name(); name == "gaussdb" {
+		t.Skip("skip gaussdb due to it only allow unique constraint matching given keys")
 	}
 
 	DB.Migrator().DropTable(&Blog{}, &Tag{}, "blog_tags", "locale_blog_tags", "shared_blog_tags")

--- a/tests/postgres_test.go
+++ b/tests/postgres_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestPostgresReturningIDWhichHasStringType(t *testing.T) {
-	if DB.Dialector.Name() != "postgres" {
+	if DB.Dialector.Name() != "postgres" || DB.Dialector.Name() != "gaussdb" {
 		t.Skip()
 	}
 
@@ -62,7 +62,7 @@ func TestPostgresReturningIDWhichHasStringType(t *testing.T) {
 }
 
 func TestPostgres(t *testing.T) {
-	if DB.Dialector.Name() != "postgres" {
+	if DB.Dialector.Name() != "postgres" || DB.Dialector.Name() != "gaussdb" {
 		t.Skip()
 	}
 
@@ -166,7 +166,7 @@ type Category struct {
 }
 
 func TestMany2ManyWithDefaultValueUUID(t *testing.T) {
-	if DB.Dialector.Name() != "postgres" {
+	if DB.Dialector.Name() != "postgres" || DB.Dialector.Name() != "gaussdb" {
 		t.Skip()
 	}
 
@@ -191,7 +191,7 @@ func TestMany2ManyWithDefaultValueUUID(t *testing.T) {
 }
 
 func TestPostgresOnConstraint(t *testing.T) {
-	if DB.Dialector.Name() != "postgres" {
+	if DB.Dialector.Name() != "postgres" || DB.Dialector.Name() != "gaussdb" {
 		t.Skip()
 	}
 

--- a/tests/serializer_test.go
+++ b/tests/serializer_test.go
@@ -45,7 +45,7 @@ type SerializerPostgresStruct struct {
 func (*SerializerPostgresStruct) TableName() string { return "serializer_structs" }
 
 func adaptorSerializerModel(s *SerializerStruct) interface{} {
-	if DB.Dialector.Name() == "postgres" {
+	if DB.Dialector.Name() == "postgres" || DB.Dialector.Name() == "gaussdb" {
 		sps := SerializerPostgresStruct(*s)
 		return &sps
 	}

--- a/tests/sql_builder_test.go
+++ b/tests/sql_builder_test.go
@@ -487,7 +487,7 @@ func replaceQuoteInSQL(sql string) string {
 
 	// convert dialect special quote into double quote
 	switch DB.Dialector.Name() {
-	case "postgres":
+	case "postgres", "gaussdb":
 		sql = strings.ReplaceAll(sql, `"`, `"`)
 	case "mysql", "sqlite":
 		sql = strings.ReplaceAll(sql, "`", `"`)

--- a/tests/table_test.go
+++ b/tests/table_test.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/moseszane168/gaussdb"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 	"gorm.io/gorm/schema"
@@ -228,6 +229,82 @@ func TestPostgresTableWithIdentifierLength(t *testing.T) {
 	t.Run("namer", func(t *testing.T) {
 		uname := "custom_unique_name"
 		db, _ := gorm.Open(postgres.Open(postgresDSN), &gorm.Config{
+			NamingStrategy: mockUniqueNamingStrategy{
+				UName: uname,
+			},
+		})
+
+		user, err := schema.Parse(&LongString{}, &sync.Map{}, db.Config.NamingStrategy)
+		if err != nil {
+			t.Fatalf("failed to parse user unique, got error %v", err)
+		}
+
+		constraints := user.ParseUniqueConstraints()
+		if len(constraints) != 1 {
+			t.Fatalf("failed to find unique constraint, got %v", constraints)
+		}
+
+		for key := range constraints {
+			if key != uname {
+				t.Errorf("failed to find unique constraint, got %v", constraints)
+			}
+		}
+	})
+}
+
+func TestPostgresTableWithIdentifierLengthGaussDB(t *testing.T) {
+	if DB.Dialector.Name() != "gaussdb" {
+		return
+	}
+
+	type LongString struct {
+		ThisIsAVeryVeryVeryVeryVeryVeryVeryVeryVeryLongString string `gorm:"unique"`
+	}
+
+	t.Run("default", func(t *testing.T) {
+		db, _ := gorm.Open(gaussdb.Open(gaussdbDSN), &gorm.Config{})
+		user, err := schema.Parse(&LongString{}, &sync.Map{}, db.Config.NamingStrategy)
+		if err != nil {
+			t.Fatalf("failed to parse user unique, got error %v", err)
+		}
+
+		constraints := user.ParseUniqueConstraints()
+		if len(constraints) != 1 {
+			t.Fatalf("failed to find unique constraint, got %v", constraints)
+		}
+
+		for key := range constraints {
+			if len(key) != 63 {
+				t.Errorf("failed to find unique constraint, got %v", constraints)
+			}
+		}
+	})
+
+	t.Run("naming strategy", func(t *testing.T) {
+		db, _ := gorm.Open(gaussdb.Open(gaussdbDSN), &gorm.Config{
+			NamingStrategy: schema.NamingStrategy{},
+		})
+
+		user, err := schema.Parse(&LongString{}, &sync.Map{}, db.Config.NamingStrategy)
+		if err != nil {
+			t.Fatalf("failed to parse user unique, got error %v", err)
+		}
+
+		constraints := user.ParseUniqueConstraints()
+		if len(constraints) != 1 {
+			t.Fatalf("failed to find unique constraint, got %v", constraints)
+		}
+
+		for key := range constraints {
+			if len(key) != 63 {
+				t.Errorf("failed to find unique constraint, got %v", constraints)
+			}
+		}
+	})
+
+	t.Run("namer", func(t *testing.T) {
+		uname := "custom_unique_name"
+		db, _ := gorm.Open(gaussdb.Open(gaussdbDSN), &gorm.Config{
 			NamingStrategy: mockUniqueNamingStrategy{
 				UName: uname,
 			},

--- a/tests/tests_test.go
+++ b/tests/tests_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/moseszane168/gaussdb"
 	"gorm.io/driver/mysql"
 	"gorm.io/driver/postgres"
 	"gorm.io/driver/sqlite"
@@ -21,6 +22,7 @@ var DB *gorm.DB
 var (
 	mysqlDSN     = "gorm:gorm@tcp(localhost:9910)/gorm?charset=utf8&parseTime=True&loc=Local"
 	postgresDSN  = "user=gorm password=gorm dbname=gorm host=localhost port=9920 sslmode=disable TimeZone=Asia/Shanghai"
+	gaussdbDSN   = "user=gaussdb password=Gaussdb@123 dbname=gorm host=localhost port=9920 sslmode=disable TimeZone=Asia/Shanghai"
 	sqlserverDSN = "sqlserver://sa:LoremIpsum86@localhost:9930?database=master"
 	tidbDSN      = "root:@tcp(localhost:9940)/test?charset=utf8&parseTime=True&loc=Local"
 )
@@ -62,6 +64,15 @@ func OpenTestConnection(cfg *gorm.Config) (db *gorm.DB, err error) {
 			dbDSN = postgresDSN
 		}
 		db, err = gorm.Open(postgres.New(postgres.Config{
+			DSN:                  dbDSN,
+			PreferSimpleProtocol: true,
+		}), cfg)
+	case "gaussdb":
+		log.Println("testing gaussdb...")
+		if dbDSN == "" {
+			dbDSN = gaussdbDSN
+		}
+		db, err = gorm.Open(gaussdb.New(gaussdb.Config{
 			DSN:                  dbDSN,
 			PreferSimpleProtocol: true,
 		}), cfg)

--- a/tests/update_test.go
+++ b/tests/update_test.go
@@ -765,9 +765,9 @@ func TestSaveWithPrimaryValue(t *testing.T) {
 	}
 }
 
-// only sqlite, postgres, sqlserver support returning
+// only sqlite, postgres, gaussdb, sqlserver support returning
 func TestUpdateReturning(t *testing.T) {
-	if DB.Dialector.Name() != "sqlite" && DB.Dialector.Name() != "postgres" && DB.Dialector.Name() != "sqlserver" {
+	if DB.Dialector.Name() != "sqlite" && DB.Dialector.Name() != "postgres" && DB.Dialector.Name() != "gaussdb" && DB.Dialector.Name() != "sqlserver" {
 		return
 	}
 
@@ -883,9 +883,9 @@ func TestSaveWithHooks(t *testing.T) {
 	}
 }
 
-// only postgres, sqlserver, sqlite support update from
+// only postgres, gaussdb, sqlserver, sqlite support update from
 func TestUpdateFrom(t *testing.T) {
-	if DB.Dialector.Name() != "postgres" && DB.Dialector.Name() != "sqlite" && DB.Dialector.Name() != "sqlserver" {
+	if DB.Dialector.Name() != "postgres" && DB.Dialector.Name() != "gaussdb" && DB.Dialector.Name() != "sqlite" && DB.Dialector.Name() != "sqlserver" {
 		return
 	}
 


### PR DESCRIPTION
Add support for Gaussian DB
1. The reason why TestPrimarykeyIDGaussDB failed is that the uuid ossp plugin cannot be created;
2. The reason why TestInvalidCachedPlanSimpleProtocolGaussDB failed is that it cannot create a table without any columns.

