### PR TITLE
change function name

### DIFF
--- a/tests/table_test.go
+++ b/tests/table_test.go
@@ -252,7 +252,7 @@ func TestPostgresTableWithIdentifierLength(t *testing.T) {
 	})
 }
 
-func TestPostgresTableWithIdentifierLengthGaussDB(t *testing.T) {
+func TestGaussDBTableWithIdentifierLength(t *testing.T) {
 	if DB.Dialector.Name() != "gaussdb" {
 		return
 	}


### PR DESCRIPTION
change function name `TestPostgresTableWithIdentifierLengthGaussDB` to `TestGaussDBTableWithIdentifierLength`